### PR TITLE
Call tests from travis CI; add build status and coverage badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+before_install:
+  - sudo pip install cpp-coveralls
+script:
+  - make CFLAGS=--coverage
+  - ./testsuite
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# pmccabe
+
+[![Build Status](https://travis-ci.org/witter-datacom/pmccabe.png?branch=master)](https://travis-ci.org/witter-datacom/pmccabe) 
+[![Coverage Status](https://coveralls.io/repos/witter-datacom/pmccabe/badge.png?branch=master)](https://coveralls.io/r/witter-datacom/pmccabe?branch=master)
+
 McCabe-style complexity and line counting for C and C++
 
 Pmccabe calculates McCabe-style cyclomatic complexity for C and C++

--- a/testsuite
+++ b/testsuite
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # $Id: testsuite,v 1.7 2001/10/25 23:51:52 bame Exp $
 
 testlist='


### PR DESCRIPTION
- .travis.yml with compiling instructions and coveralls coverage report
- README.md added, with content from the "description" file
- testsuite must be executed with bash, not sh - fixed

For this to work, please create an account at https://travis-ci.org/ and https://coveralls.io/

Cheers
